### PR TITLE
Add newline, fix #71

### DIFF
--- a/sign/pdftrailer.go
+++ b/sign/pdftrailer.go
@@ -43,7 +43,7 @@ func (context *SignContext) writeTrailer() error {
 				lines[i] = "    " + strings.TrimSpace(line)
 			}
 		}
-		trailer_string = strings.Join(lines, "\n")
+		trailer_string = strings.Join(lines, "\n") + "\n"
 
 		// Write the new trailer.
 		if _, err := context.OutputBuffer.Write([]byte(trailer_string)); err != nil {
@@ -54,7 +54,6 @@ func (context *SignContext) writeTrailer() error {
 			return err
 		}
 	}
-
 	// Write the new xref start position.
 	if _, err := context.OutputBuffer.Write([]byte(strconv.FormatInt(context.NewXrefStart, 10) + "\n")); err != nil {
 		return err


### PR DESCRIPTION
This pull request makes minor adjustments to the `writeTrailer` function in the `sign/pdftrailer.go` file to ensure proper formatting of the PDF trailer.

Formatting improvements:

* Added a newline character to the `trailer_string` after joining lines to ensure the trailer ends with a newline. (`[sign/pdftrailer.goL46-R46](diffhunk://#diff-65ef2b5fadde38d8a68274a6553a064bdc9106ff13a673fdf9cb5f1fe8b31008L46-R46)`)
