### PR TITLE
Fix devcontainer git ssh

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,0 @@
-FROM golang:1.23-bullseye
-
-# Creates an app directory to hold your app’s source code
-WORKDIR /app

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,22 +1,11 @@
 {
     "name": "Go PDF Sign",
-    "dockerFile": "Dockerfile",
-    "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
+    "image": "mcr.microsoft.com/devcontainers/go:1-1.23-bookworm",
     "customizations": {
         "vscode": {
-            "settings": {
-                "terminal.integrated.shell.linux": "/bin/bash",
-                "go.toolsManagement.checkForUpdates": "local",
-                "go.useLanguageServer": true,
-                "go.gopath": "/go"
-            },
-            "extensions": ["golang.go"]
+            "settings": {},
+            "extensions": ["streetsidesoftware.code-spell-checker"]
         }
     },
-    "containerEnv": {
-        "TMPDIR": "/workspaces/pdfsign/tmp"
-    },
-    "forwardPorts": [],
-    "postCreateCommand": "go mod download",
-    "remoteUser": "root"
+    "postCreateCommand": "echo 'export TMPDIR=/workspaces/pdfsign/tmp' >> ~/.bashrc"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "customizations": {
         "vscode": {
             "settings": {},
-            "extensions": ["streetsidesoftware.code-spell-checker"]
+            "extensions": ["golang.go"]
         }
     },
     "postCreateCommand": "echo 'export TMPDIR=/workspaces/pdfsign/tmp' >> ~/.bashrc"


### PR DESCRIPTION
For some reasons `containerEnv` erase all predefined env variables including the one forwarding the ssh agent. 
This small trick fixes it and allows to push code from the devcontainer.