### PR TITLE
Return signature info after signing and verifying

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,27 +97,34 @@ A PDF signing and verification library written in [Go](https://go.dev). This lib
 
 ### Verification Output
 
-The verification command outputs JSON with the following key fields:
 
-| Field | Description |
-|-------|-------------|
-| `ValidSignature` | Whether the cryptographic signature is mathematically valid |
-| `TrustedIssuer` | Whether the certificate chain is trusted by system root certificates |
-| `RevokedCertificate` | Whether any certificate in the chain has been revoked before signing |
-| `KeyUsageValid` | Whether the certificate has appropriate key usage for PDF signing |
-| `ExtKeyUsageValid` | Whether the certificate has proper Extended Key Usage (EKU) values |
-| `TimestampStatus` | Status of embedded timestamp: "valid", "invalid", or "missing" |
-| `TimestampTrusted` | Whether the timestamp token's certificate chain is trusted |
-| `VerificationTime` | The time used for certificate validation |
-| `TimeSource` | Source of verification time: "embedded_timestamp", "signature_time", or "current_time" |
-| `TimeWarnings` | Warnings about time validation (e.g., using untrusted signature time) |
-| `OCSPEmbedded` | Whether OCSP response is embedded in the PDF |
-| `OCSPExternal` | Whether external OCSP checking was performed |
-| `CRLEmbedded` | Whether CRL is embedded in the PDF |
-| `CRLExternal` | Whether external CRL checking was performed |
-| `RevocationTime` | When the certificate was revoked (if applicable) |
-| `RevokedBeforeSigning` | Whether revocation occurred before the signing time |
-| `RevocationWarning` | Human-readable warning about revocation status checking |
+#### Key Fields
+
+| Field | Location | Description |
+|-------|----------|-------------|
+| `Error` | top-level | Error message if verification failed |
+| `DocumentInfo` | top-level | PDF document metadata |
+| `Signatures` | top-level | Array of signature results |
+| `Info` | Signatures[] | Signer and signature metadata |
+| `Validation` | Signatures[] | Validation results for the signature |
+| `valid_signature` | Signatures[].Validation | Whether the cryptographic signature is mathematically valid |
+| `trusted_issuer` | Signatures[].Validation | Whether the certificate chain is trusted by system root certificates |
+| `revoked_certificate` | Signatures[].Validation | Whether any certificate in the chain has been revoked before signing |
+| `certificates` | Signatures[].Validation | Array of certificate validation results |
+| `timestamp_status` | Signatures[].Validation | Status of embedded timestamp: "valid", "invalid", or "missing" |
+| `timestamp_trusted` | Signatures[].Validation | Whether the timestamp token's certificate chain is trusted |
+| `verification_time` | Signatures[].Validation | The time used for certificate validation |
+| `time_source` | Signatures[].Validation | Source of verification time: "embedded_timestamp", "signature_time", or "current_time" |
+| `time_warnings` | Signatures[].Validation | Warnings about time validation (e.g., using untrusted signature time) |
+| `key_usage_valid` | Signatures[].Validation.Certificates[] | Whether the certificate has appropriate key usage for PDF signing |
+| `ext_key_usage_valid` | Signatures[].Validation.Certificates[] | Whether the certificate has proper Extended Key Usage (EKU) values |
+| `ocsp_embedded` | Signatures[].Validation.Certificates[] | Whether OCSP response is embedded in the PDF |
+| `ocsp_external` | Signatures[].Validation.Certificates[] | Whether external OCSP checking was performed |
+| `crl_embedded` | Signatures[].Validation.Certificates[] | Whether CRL is embedded in the PDF |
+| `crl_external` | Signatures[].Validation.Certificates[] | Whether external CRL checking was performed |
+| `revocation_time` | Signatures[].Validation.Certificates[] | When the certificate was revoked (if applicable) |
+| `revoked_before_signing` | Signatures[].Validation.Certificates[] | Whether revocation occurred before the signing time |
+| `revocation_warning` | Signatures[].Validation.Certificates[] | Human-readable warning about revocation status checking |
 
 ## Go Library Usage
 

--- a/cli/sign.go
+++ b/cli/sign.go
@@ -101,7 +101,7 @@ func signPDFImpl(input string, args []string) {
 
 	cert, pkey, certificateChains := LoadCertificatesAndKey(certPath, keyPath, chainPath)
 
-	err = sign.SignFile(input, output, sign.SignData{
+	_, err = sign.SignFile(input, output, sign.SignData{
 		Signature: sign.SignDataSignature{
 			Info: sign.SignDataSignatureInfo{
 				Name:        InfoName,
@@ -196,7 +196,7 @@ func LoadCertificateChain(chainPath string, cert *x509.Certificate) [][]*x509.Ce
 }
 
 func TimeStampPDF(input, output, tsa string) {
-	err := sign.SignFile(input, output, sign.SignData{
+	_, err := sign.SignFile(input, output, sign.SignData{
 		Signature: sign.SignDataSignature{
 			CertType: sign.TimeStampSignature,
 		},

--- a/common/types.go
+++ b/common/types.go
@@ -1,0 +1,61 @@
+package common
+
+import (
+	"crypto/x509"
+	"time"
+
+	"github.com/digitorus/timestamp"
+	"golang.org/x/crypto/ocsp"
+)
+
+// DocumentInfo contains document information that can be extracted from any PDF.
+// This is moved from verify package since it represents generic PDF metadata.
+type DocumentInfo struct {
+	Author     string `json:"author"`
+	Creator    string `json:"creator"`
+	Hash       string `json:"hash"`
+	Name       string `json:"name"`
+	Permission string `json:"permission"`
+	Producer   string `json:"producer"`
+	Subject    string `json:"subject"`
+	Title      string `json:"title"`
+
+	Pages        int       `json:"pages"`
+	Keywords     []string  `json:"keywords"`
+	ModDate      time.Time `json:"mod_date"`
+	CreationDate time.Time `json:"creation_date"`
+}
+
+// SignatureInfo contains information about the signer and signature.
+// This consolidates the duplicated SignatureInfo types from both packages.
+type SignatureInfo struct {
+	Name          string               `json:"name"`
+	Reason        string               `json:"reason"`
+	Location      string               `json:"location"`
+	ContactInfo   string               `json:"contact_info"`
+	SignatureTime *time.Time           `json:"signature_time,omitempty"`
+	TimeStamp     *timestamp.Timestamp `json:"time_stamp,omitempty"`
+	DocumentHash  string               `json:"document_hash"`
+	SignatureHash string               `json:"signature_hash"`
+	HashAlgorithm string               `json:"hash_algorithm"`
+}
+
+// Certificate contains certificate information and validation results.
+// This is moved from verify package but could be useful for signing operations too.
+type Certificate struct {
+	Certificate          *x509.Certificate `json:"certificate"`
+	VerifyError          string            `json:"verify_error"`
+	KeyUsageValid        bool              `json:"key_usage_valid"`
+	KeyUsageError        string            `json:"key_usage_error,omitempty"`
+	ExtKeyUsageValid     bool              `json:"ext_key_usage_valid"`
+	ExtKeyUsageError     string            `json:"ext_key_usage_error,omitempty"`
+	OCSPResponse         *ocsp.Response    `json:"ocsp_response"`
+	OCSPEmbedded         bool              `json:"ocsp_embedded"`
+	OCSPExternal         bool              `json:"ocsp_external"`
+	CRLRevoked           time.Time         `json:"crl_revoked"`
+	CRLEmbedded          bool              `json:"crl_embedded"`
+	CRLExternal          bool              `json:"crl_external"`
+	RevocationWarning    string            `json:"revocation_warning,omitempty"`
+	RevocationTime       *time.Time        `json:"revocation_time,omitempty"` // When the certificate was revoked (if applicable)
+	RevokedBeforeSigning bool              `json:"revoked_before_signing"`    // Whether revocation occurred before signing
+}

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -9,13 +9,13 @@ import (
 	"os"
 
 	"github.com/digitorus/pdf"
-	"github.com/digitorus/pdfsign/verify"
+	"github.com/digitorus/pdfsign/common"
 	"github.com/digitorus/pkcs7"
 
 	"github.com/mattetti/filebuffer"
 )
 
-func SignFile(input string, output string, sign_data SignData) (*verify.SignatureInfo, error) {
+func SignFile(input string, output string, sign_data SignData) (*common.SignatureInfo, error) {
 	input_file, err := os.Open(input)
 	if err != nil {
 		return nil, err
@@ -46,7 +46,7 @@ func SignFile(input string, output string, sign_data SignData) (*verify.Signatur
 	return Sign(input_file, output_file, rdr, size, sign_data)
 }
 
-func Sign(input io.ReadSeeker, output io.Writer, rdr *pdf.Reader, size int64, sign_data SignData) (*verify.SignatureInfo, error) {
+func Sign(input io.ReadSeeker, output io.Writer, rdr *pdf.Reader, size int64, sign_data SignData) (*common.SignatureInfo, error) {
 	sign_data.objectId = uint32(rdr.XrefInformation.ItemCount) + 2
 
 	context := SignContext{
@@ -72,7 +72,7 @@ func Sign(input io.ReadSeeker, output io.Writer, rdr *pdf.Reader, size int64, si
 	return signatureInfo, nil
 }
 
-func (context *SignContext) SignPDF() (*verify.SignatureInfo, error) {
+func (context *SignContext) SignPDF() (*common.SignatureInfo, error) {
 	// set defaults
 	if context.SignData.Signature.CertType == 0 {
 		context.SignData.Signature.CertType = 1
@@ -273,7 +273,7 @@ func (context *SignContext) SignPDF() (*verify.SignatureInfo, error) {
 	}
 
 	// Create and return signature info
-	signatureInfo := &verify.SignatureInfo{
+	signatureInfo := &common.SignatureInfo{
 		Name:          context.SignData.Signature.Info.Name,
 		Reason:        context.SignData.Signature.Info.Reason,
 		Location:      context.SignData.Signature.Info.Location,

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -9,15 +9,16 @@ import (
 	"os"
 
 	"github.com/digitorus/pdf"
+	"github.com/digitorus/pdfsign/verify"
 	"github.com/digitorus/pkcs7"
 
 	"github.com/mattetti/filebuffer"
 )
 
-func SignFile(input string, output string, sign_data SignData) error {
+func SignFile(input string, output string, sign_data SignData) (*verify.SignatureInfo, error) {
 	input_file, err := os.Open(input)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer func() {
 		_ = input_file.Close()
@@ -25,7 +26,7 @@ func SignFile(input string, output string, sign_data SignData) error {
 
 	output_file, err := os.Create(output)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer func() {
 		_ = output_file.Close()
@@ -33,19 +34,19 @@ func SignFile(input string, output string, sign_data SignData) error {
 
 	finfo, err := input_file.Stat()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	size := finfo.Size()
 
 	rdr, err := pdf.NewReader(input_file, size)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	return Sign(input_file, output_file, rdr, size, sign_data)
 }
 
-func Sign(input io.ReadSeeker, output io.Writer, rdr *pdf.Reader, size int64, sign_data SignData) error {
+func Sign(input io.ReadSeeker, output io.Writer, rdr *pdf.Reader, size int64, sign_data SignData) (*verify.SignatureInfo, error) {
 	sign_data.objectId = uint32(rdr.XrefInformation.ItemCount) + 2
 
 	context := SignContext{
@@ -59,19 +60,19 @@ func Sign(input io.ReadSeeker, output io.Writer, rdr *pdf.Reader, size int64, si
 	// Fetch existing signatures
 	existingSignatures, err := context.fetchExistingSignatures()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	context.existingSignatures = existingSignatures
 
-	err = context.SignPDF()
+	signatureInfo, err := context.SignPDF()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return signatureInfo, nil
 }
 
-func (context *SignContext) SignPDF() error {
+func (context *SignContext) SignPDF() (*verify.SignatureInfo, error) {
 	// set defaults
 	if context.SignData.Signature.CertType == 0 {
 		context.SignData.Signature.CertType = 1
@@ -91,15 +92,15 @@ func (context *SignContext) SignPDF() error {
 	// Copy old file into new buffer.
 	_, err := context.InputFile.Seek(0, 0)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if _, err := io.Copy(context.OutputBuffer, context.InputFile); err != nil {
-		return err
+		return nil, err
 	}
 
 	// File always needs an empty line after %%EOF.
 	if _, err := context.OutputBuffer.Write([]byte("\n")); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Base size for signature.
@@ -108,7 +109,7 @@ func (context *SignContext) SignPDF() error {
 	// If not a timestamp signature
 	if context.SignData.Signature.CertType != TimeStampSignature {
 		if context.SignData.Certificate == nil {
-			return fmt.Errorf("certificate is required")
+			return nil, fmt.Errorf("certificate is required")
 		}
 
 		switch context.SignData.Certificate.SignatureAlgorithm.String() {
@@ -134,7 +135,7 @@ func (context *SignContext) SignPDF() error {
 		// Add size for my certificate.
 		degenerated, err := pkcs7.DegenerateCertificate(context.SignData.Certificate.Raw)
 		if err != nil {
-			return fmt.Errorf("failed to degenerate certificate: %w", err)
+			return nil, fmt.Errorf("failed to degenerate certificate: %w", err)
 		}
 
 		context.SignatureMaxLength += uint32(hex.EncodedLen(len(degenerated)))
@@ -152,7 +153,7 @@ func (context *SignContext) SignPDF() error {
 			for _, cert := range certificate_chain {
 				degenerated, err := pkcs7.DegenerateCertificate(cert.Raw)
 				if err != nil {
-					return fmt.Errorf("failed to degenerate certificate in chain: %w", err)
+					return nil, fmt.Errorf("failed to degenerate certificate in chain: %w", err)
 				}
 
 				context.SignatureMaxLength += uint32(hex.EncodedLen(len(degenerated)))
@@ -162,7 +163,7 @@ func (context *SignContext) SignPDF() error {
 		// Fetch revocation data before adding signature placeholder.
 		// Revocation data can be quite large and we need to create enough space in the placeholder.
 		if err := context.fetchRevocationData(); err != nil {
-			return fmt.Errorf("failed to fetch revocation data: %w", err)
+			return nil, fmt.Errorf("failed to fetch revocation data: %w", err)
 		}
 	}
 
@@ -188,14 +189,14 @@ func (context *SignContext) SignPDF() error {
 	// Write the new signature object
 	context.SignData.objectId, err = context.addObject(signature_object)
 	if err != nil {
-		return fmt.Errorf("failed to add signature object: %w", err)
+		return nil, fmt.Errorf("failed to add signature object: %w", err)
 	}
 
 	// Create visual signature (visible or invisible based on CertType)
 	visible := false
 	rectangle := [4]float64{0, 0, 0, 0}
 	if context.SignData.Signature.CertType != ApprovalSignature && context.SignData.Appearance.Visible {
-		return fmt.Errorf("visible signatures are only allowed for approval signatures")
+		return nil, fmt.Errorf("visible signatures are only allowed for approval signatures")
 	} else if context.SignData.Signature.CertType == ApprovalSignature && context.SignData.Appearance.Visible {
 		visible = true
 		rectangle = [4]float64{
@@ -209,67 +210,88 @@ func (context *SignContext) SignPDF() error {
 	// Example usage: passing page number and default rect values
 	visual_signature, err := context.createVisualSignature(visible, context.SignData.Appearance.Page, rectangle)
 	if err != nil {
-		return fmt.Errorf("failed to create visual signature: %w", err)
+		return nil, fmt.Errorf("failed to create visual signature: %w", err)
 	}
 
 	// Write the new visual signature object.
 	context.VisualSignData.objectId, err = context.addObject(visual_signature)
 	if err != nil {
-		return fmt.Errorf("failed to add visual signature object: %w", err)
+		return nil, fmt.Errorf("failed to add visual signature object: %w", err)
 	}
 
 	if context.SignData.Appearance.Visible {
 		inc_page_update, err := context.createIncPageUpdate(context.SignData.Appearance.Page, context.VisualSignData.objectId)
 		if err != nil {
-			return fmt.Errorf("failed to create incremental page update: %w", err)
+			return nil, fmt.Errorf("failed to create incremental page update: %w", err)
 		}
 		err = context.updateObject(context.VisualSignData.pageObjectId, inc_page_update)
 		if err != nil {
-			return fmt.Errorf("failed to add incremental page update object: %w", err)
+			return nil, fmt.Errorf("failed to add incremental page update object: %w", err)
 		}
 	}
 
 	// Create a new catalog object
 	catalog, err := context.createCatalog()
 	if err != nil {
-		return fmt.Errorf("failed to create catalog: %w", err)
+		return nil, fmt.Errorf("failed to create catalog: %w", err)
 	}
 
 	// Write the new catalog object
 	context.CatalogData.ObjectId, err = context.addObject(catalog)
 	if err != nil {
-		return fmt.Errorf("failed to add catalog object: %w", err)
+		return nil, fmt.Errorf("failed to add catalog object: %w", err)
 	}
 
 	// Write xref table
 	if err := context.writeXref(); err != nil {
-		return fmt.Errorf("failed to write xref: %w", err)
+		return nil, fmt.Errorf("failed to write xref: %w", err)
 	}
 
 	// Write trailer
 	if err := context.writeTrailer(); err != nil {
-		return fmt.Errorf("failed to write trailer: %w", err)
+		return nil, fmt.Errorf("failed to write trailer: %w", err)
 	}
 
 	// Update byte range
 	if err := context.updateByteRange(); err != nil {
-		return fmt.Errorf("failed to update byte range: %w", err)
+		return nil, fmt.Errorf("failed to update byte range: %w", err)
 	}
 
 	// Replace signature
 	if err := context.replaceSignature(); err != nil {
-		return fmt.Errorf("failed to replace signature: %w", err)
+		return nil, fmt.Errorf("failed to replace signature: %w", err)
 	}
 
 	// Write final output
 	if _, err := context.OutputBuffer.Seek(0, 0); err != nil {
-		return err
+		return nil, err
 	}
 	file_content := context.OutputBuffer.Buff.Bytes()
 
 	if _, err := context.OutputFile.Write(file_content); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	// Create and return signature info
+	signatureInfo := &verify.SignatureInfo{
+		Name:          context.SignData.Signature.Info.Name,
+		Reason:        context.SignData.Signature.Info.Reason,
+		Location:      context.SignData.Signature.Info.Location,
+		ContactInfo:   context.SignData.Signature.Info.ContactInfo,
+		DocumentHash:  context.computedDocumentHash,
+		SignatureHash: context.computedSignatureHash,
+		HashAlgorithm: context.SignData.DigestAlgorithm.String(),
+	}
+
+	// Set signature time
+	if !context.SignData.Signature.Info.Date.IsZero() {
+		signatureInfo.SignatureTime = &context.SignData.Signature.Info.Date
+	}
+
+	// Set timestamp if available
+	if context.computedTimeStamp != nil {
+		signatureInfo.TimeStamp = context.computedTimeStamp
+	}
+
+	return signatureInfo, nil
 }

--- a/sign/sign_test.go
+++ b/sign/sign_test.go
@@ -225,14 +225,14 @@ func TestSignPDFFileUTF8(t *testing.T) {
 		if err := os.Rename(tmpfile.Name(), "../testfiles/failed/"+originalFileName); err != nil {
 			t.Error(err)
 		}
-	} else if len(info.Signers) == 0 {
-		t.Fatalf("no signers found in %s", tmpfile.Name())
+	} else if len(info.Signatures) == 0 {
+		t.Fatalf("no signatures found in %s", tmpfile.Name())
 	} else {
-		if info.Signers[0].Name != signerName {
-			t.Fatalf("expected %q, got %q", signerName, info.Signers[0].Name)
+		if info.Signatures[0].Info.Name != signerName {
+			t.Fatalf("expected %q, got %q", signerName, info.Signatures[0].Info.Name)
 		}
-		if info.Signers[0].Location != signerLocation {
-			t.Fatalf("expected %q, got %q", signerLocation, info.Signers[0].Location)
+		if info.Signatures[0].Info.Location != signerLocation {
+			t.Fatalf("expected %q, got %q", signerLocation, info.Signatures[0].Info.Location)
 		}
 	}
 }

--- a/sign/types.go
+++ b/sign/types.go
@@ -95,25 +95,8 @@ type SignDataSignatureInfo struct {
 	Date        time.Time
 }
 
-// SignatureInfo contains information about the signer and signature
-// (not related to validation)
-type SignatureInfo struct {
-	Name        string    `json:"name"`
-	Reason      string    `json:"reason"`
-	Location    string    `json:"location"`
-	ContactInfo string    `json:"contact_info"`
-	Date        time.Time `json:"date"`
-}
-
-// SignatureValidation contains validation results and technical details
-// (not about the signer's intent)
-type SignatureValidation struct {
-	ValidSignature bool   `json:"valid_signature"`
-	TrustedIssuer  bool   `json:"trusted_issuer"`
-	DocumentHash   string `json:"document_hash"`
-	SignatureHash  string `json:"signature_hash"`
-	HashAlgorithm  string `json:"hash_algorithm"`
-}
+// Remove the duplicated SignatureInfo and SignatureValidation types
+// They are now available in the common package
 
 type SignContext struct {
 	InputFile              io.ReadSeeker

--- a/sign/types.go
+++ b/sign/types.go
@@ -94,6 +94,26 @@ type SignDataSignatureInfo struct {
 	Date        time.Time
 }
 
+// SignatureInfo contains information about the signer and signature
+// (not related to validation)
+type SignatureInfo struct {
+	Name        string    `json:"name"`
+	Reason      string    `json:"reason"`
+	Location    string    `json:"location"`
+	ContactInfo string    `json:"contact_info"`
+	Date        time.Time `json:"date"`
+}
+
+// SignatureValidation contains validation results and technical details
+// (not about the signer's intent)
+type SignatureValidation struct {
+	ValidSignature bool   `json:"valid_signature"`
+	TrustedIssuer  bool   `json:"trusted_issuer"`
+	DocumentHash   string `json:"document_hash"`
+	SignatureHash  string `json:"signature_hash"`
+	HashAlgorithm  string `json:"hash_algorithm"`
+}
+
 type SignContext struct {
 	InputFile              io.ReadSeeker
 	OutputFile             io.Writer

--- a/sign/types.go
+++ b/sign/types.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/digitorus/pdf"
 	"github.com/digitorus/pdfsign/revocation"
+	"github.com/digitorus/timestamp"
 	"github.com/mattetti/filebuffer"
 )
 
@@ -132,4 +133,9 @@ type SignContext struct {
 	lastXrefID         uint32
 	newXrefEntries     []xrefEntry
 	updatedXrefEntries []xrefEntry
+
+	// Computed signature information
+	computedDocumentHash  string
+	computedSignatureHash string
+	computedTimeStamp     *timestamp.Timestamp
 }

--- a/verify/certificate.go
+++ b/verify/certificate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/digitorus/pdfsign/common"
 	"github.com/digitorus/pdfsign/revocation"
 	"github.com/digitorus/pkcs7"
 	"github.com/digitorus/timestamp"
@@ -12,7 +13,7 @@ import (
 )
 
 // buildCertificateChainsWithOptions builds certificate chains with custom verification options
-func buildCertificateChainsWithOptions(p7 *pkcs7.PKCS7, info *SignatureInfo, validation *SignatureValidation, revInfo revocation.InfoArchival, options *VerifyOptions) (string, error) {
+func buildCertificateChainsWithOptions(p7 *pkcs7.PKCS7, info *common.SignatureInfo, validation *SignatureValidation, revInfo revocation.InfoArchival, options *VerifyOptions) (string, error) {
 	// Directory of certificates, including OCSP
 	certPool := x509.NewCertPool()
 	for _, cert := range p7.Certificates {
@@ -126,7 +127,7 @@ func buildCertificateChainsWithOptions(p7 *pkcs7.PKCS7, info *SignatureInfo, val
 	}
 
 	for _, cert := range p7.Certificates {
-		var c Certificate
+		var c common.Certificate
 		c.Certificate = cert
 
 		// Validate Key Usage and Extended Key Usage for PDF signing

--- a/verify/certificate.go
+++ b/verify/certificate.go
@@ -12,7 +12,7 @@ import (
 )
 
 // buildCertificateChainsWithOptions builds certificate chains with custom verification options
-func buildCertificateChainsWithOptions(p7 *pkcs7.PKCS7, signer *Signer, revInfo revocation.InfoArchival, options *VerifyOptions) (string, error) {
+func buildCertificateChainsWithOptions(p7 *pkcs7.PKCS7, info *SignatureInfo, validation *SignatureValidation, revInfo revocation.InfoArchival, options *VerifyOptions) (string, error) {
 	// Directory of certificates, including OCSP
 	certPool := x509.NewCertPool()
 	for _, cert := range p7.Certificates {
@@ -23,40 +23,40 @@ func buildCertificateChainsWithOptions(p7 *pkcs7.PKCS7, signer *Signer, revInfo 
 	var verificationTime *time.Time
 
 	// Initialize time tracking fields
-	signer.TimeSource = "current_time"
-	signer.TimeWarnings = []string{}
-	signer.TimestampStatus = "missing"
-	signer.TimestampTrusted = false
+	validation.TimeSource = "current_time"
+	validation.TimeWarnings = []string{}
+	validation.TimestampStatus = "missing"
+	validation.TimestampTrusted = false
 
 	// Always prioritize embedded timestamp if present
-	if signer.TimeStamp != nil && !signer.TimeStamp.Time.IsZero() {
-		verificationTime = &signer.TimeStamp.Time
-		signer.TimeSource = "embedded_timestamp"
-		signer.TimestampStatus = "valid"
+	if info.TimeStamp != nil && !info.TimeStamp.Time.IsZero() {
+		verificationTime = &info.TimeStamp.Time
+		validation.TimeSource = "embedded_timestamp"
+		validation.TimestampStatus = "valid"
 
 		// Validate timestamp certificate if enabled
 		if options.ValidateTimestampCertificates {
-			timestampTrusted, timestampWarning := validateTimestampCertificate(signer.TimeStamp, options)
-			signer.TimestampTrusted = timestampTrusted
+			timestampTrusted, timestampWarning := validateTimestampCertificate(info.TimeStamp, options)
+			validation.TimestampTrusted = timestampTrusted
 			if timestampWarning != "" {
-				signer.TimeWarnings = append(signer.TimeWarnings, timestampWarning)
+				validation.TimeWarnings = append(validation.TimeWarnings, timestampWarning)
 			}
 		}
-	} else if options.TrustSignatureTime && signer.SignatureTime != nil {
+	} else if options.TrustSignatureTime && info.SignatureTime != nil {
 		// Use signature time as fallback with warning about its untrusted nature
-		verificationTime = signer.SignatureTime
-		signer.TimeSource = "signature_time"
-		signer.TimeWarnings = append(signer.TimeWarnings,
+		verificationTime = info.SignatureTime
+		validation.TimeSource = "signature_time"
+		validation.TimeWarnings = append(validation.TimeWarnings,
 			"Using signature time as fallback - this time is provided by the signatory and should be considered untrusted")
 	}
 	// If verificationTime is nil, x509.Verify will use current time (default behavior)
 
 	// Set the verification time used
 	if verificationTime != nil {
-		signer.VerificationTime = verificationTime
+		validation.VerificationTime = verificationTime
 	} else {
 		currentTime := time.Now()
-		signer.VerificationTime = &currentTime
+		validation.VerificationTime = &currentTime
 	}
 
 	// Parse OCSP response
@@ -169,21 +169,21 @@ func buildCertificateChainsWithOptions(p7 *pkcs7.PKCS7, signer *Signer, revInfo 
 			if resp.Status != ocsp.Good {
 				c.RevocationTime = &resp.RevokedAt
 				// Check if revocation occurred before signing
-				revokedBeforeSigning := isRevokedBeforeSigning(resp.RevokedAt, signer.VerificationTime, signer.TimeSource)
+				revokedBeforeSigning := isRevokedBeforeSigning(resp.RevokedAt, validation.VerificationTime, validation.TimeSource)
 				c.RevokedBeforeSigning = revokedBeforeSigning
 
 				if revokedBeforeSigning {
-					signer.RevokedCertificate = true
+					validation.RevokedCertificate = true
 				} else {
 					// Add warning that certificate was revoked after signing
-					if signer.TimeSource == "embedded_timestamp" {
-						signer.TimeWarnings = append(signer.TimeWarnings,
+					if validation.TimeSource == "embedded_timestamp" {
+						validation.TimeWarnings = append(validation.TimeWarnings,
 							fmt.Sprintf("Certificate was revoked after signing time (revoked: %v, signed: %v)",
-								resp.RevokedAt, signer.VerificationTime))
+								resp.RevokedAt, validation.VerificationTime))
 					} else {
 						// Without trusted timestamp, we must assume revocation invalidates signature
-						signer.RevokedCertificate = true
-						signer.TimeWarnings = append(signer.TimeWarnings,
+						validation.RevokedCertificate = true
+						validation.TimeWarnings = append(validation.TimeWarnings,
 							"Certificate revoked, but cannot determine if revocation occurred before or after signing without trusted timestamp")
 					}
 				}
@@ -213,21 +213,21 @@ func buildCertificateChainsWithOptions(p7 *pkcs7.PKCS7, signer *Signer, revInfo 
 			c.RevocationTime = revocationTime
 
 			// Check if revocation occurred before signing
-			revokedBeforeSigning := isRevokedBeforeSigning(*revocationTime, signer.VerificationTime, signer.TimeSource)
+			revokedBeforeSigning := isRevokedBeforeSigning(*revocationTime, validation.VerificationTime, validation.TimeSource)
 			c.RevokedBeforeSigning = revokedBeforeSigning
 
 			if revokedBeforeSigning {
-				signer.RevokedCertificate = true
+				validation.RevokedCertificate = true
 			} else {
 				// Add warning that certificate was revoked after signing
-				if signer.TimeSource == "embedded_timestamp" {
-					signer.TimeWarnings = append(signer.TimeWarnings,
+				if validation.TimeSource == "embedded_timestamp" {
+					validation.TimeWarnings = append(validation.TimeWarnings,
 						fmt.Sprintf("Certificate was revoked after signing time (revoked: %v, signed: %v)",
-							revocationTime, signer.VerificationTime))
+							revocationTime, validation.VerificationTime))
 				} else {
 					// Without trusted timestamp, we must assume revocation invalidates signature
-					signer.RevokedCertificate = true
-					signer.TimeWarnings = append(signer.TimeWarnings,
+					validation.RevokedCertificate = true
+					validation.TimeWarnings = append(validation.TimeWarnings,
 						"Certificate revoked, but cannot determine if revocation occurred before or after signing without trusted timestamp")
 				}
 			}
@@ -248,21 +248,21 @@ func buildCertificateChainsWithOptions(p7 *pkcs7.PKCS7, signer *Signer, revInfo 
 					if externalOCSPResp.Status != ocsp.Good {
 						c.RevocationTime = &externalOCSPResp.RevokedAt
 						// Check if revocation occurred before signing
-						revokedBeforeSigning := isRevokedBeforeSigning(externalOCSPResp.RevokedAt, signer.VerificationTime, signer.TimeSource)
+						revokedBeforeSigning := isRevokedBeforeSigning(externalOCSPResp.RevokedAt, validation.VerificationTime, validation.TimeSource)
 						c.RevokedBeforeSigning = revokedBeforeSigning
 
 						if revokedBeforeSigning {
-							signer.RevokedCertificate = true
+							validation.RevokedCertificate = true
 						} else {
 							// Add warning that certificate was revoked after signing
-							if signer.TimeSource == "embedded_timestamp" {
-								signer.TimeWarnings = append(signer.TimeWarnings,
+							if validation.TimeSource == "embedded_timestamp" {
+								validation.TimeWarnings = append(validation.TimeWarnings,
 									fmt.Sprintf("Certificate was revoked after signing time (external OCSP - revoked: %v, signed: %v)",
-										externalOCSPResp.RevokedAt, signer.VerificationTime))
+										externalOCSPResp.RevokedAt, validation.VerificationTime))
 							} else {
 								// Without trusted timestamp, we must assume revocation invalidates signature
-								signer.RevokedCertificate = true
-								signer.TimeWarnings = append(signer.TimeWarnings,
+								validation.RevokedCertificate = true
+								validation.TimeWarnings = append(validation.TimeWarnings,
 									"Certificate revoked (external OCSP), but cannot determine if revocation occurred before or after signing without trusted timestamp")
 							}
 						}
@@ -277,21 +277,21 @@ func buildCertificateChainsWithOptions(p7 *pkcs7.PKCS7, signer *Signer, revInfo 
 					if isRevoked {
 						c.RevocationTime = revocationTime
 						// Check if revocation occurred before signing
-						revokedBeforeSigning := isRevokedBeforeSigning(*revocationTime, signer.VerificationTime, signer.TimeSource)
+						revokedBeforeSigning := isRevokedBeforeSigning(*revocationTime, validation.VerificationTime, validation.TimeSource)
 						c.RevokedBeforeSigning = revokedBeforeSigning
 
 						if revokedBeforeSigning {
-							signer.RevokedCertificate = true
+							validation.RevokedCertificate = true
 						} else {
 							// Add warning that certificate was revoked after signing
-							if signer.TimeSource == "embedded_timestamp" {
-								signer.TimeWarnings = append(signer.TimeWarnings,
+							if validation.TimeSource == "embedded_timestamp" {
+								validation.TimeWarnings = append(validation.TimeWarnings,
 									fmt.Sprintf("Certificate was revoked after signing time (external CRL - revoked: %v, signed: %v)",
-										revocationTime, signer.VerificationTime))
+										revocationTime, validation.VerificationTime))
 							} else {
 								// Without trusted timestamp, we must assume revocation invalidates signature
-								signer.RevokedCertificate = true
-								signer.TimeWarnings = append(signer.TimeWarnings,
+								validation.RevokedCertificate = true
+								validation.TimeWarnings = append(validation.TimeWarnings,
 									"Certificate revoked (external CRL), but cannot determine if revocation occurred before or after signing without trusted timestamp")
 							}
 						}
@@ -342,11 +342,11 @@ func buildCertificateChainsWithOptions(p7 *pkcs7.PKCS7, signer *Signer, revInfo 
 		}
 
 		// Add certificate to result
-		signer.Certificates = append(signer.Certificates, c)
+		validation.Certificates = append(validation.Certificates, c)
 	}
 
 	// Set trusted issuer flag based on whether any certificate was verified against system roots
-	signer.TrustedIssuer = trustedIssuer
+	validation.TrustedIssuer = trustedIssuer
 
 	return errorMsg, nil
 }

--- a/verify/document.go
+++ b/verify/document.go
@@ -7,10 +7,11 @@ import (
 	"time"
 
 	"github.com/digitorus/pdf"
+	"github.com/digitorus/pdfsign/common"
 )
 
 // parseDocumentInfo parses document information from PDF Info dictionary.
-func parseDocumentInfo(v pdf.Value, documentInfo *DocumentInfo) {
+func parseDocumentInfo(v pdf.Value, documentInfo *common.DocumentInfo) {
 	keys := []string{
 		"Author", "CreationDate", "Creator", "Hash", "Keywords", "ModDate",
 		"Name", "Pages", "Permission", "Producer", "Subject", "Title",

--- a/verify/keyusage_test.go
+++ b/verify/keyusage_test.go
@@ -315,9 +315,7 @@ func TestTimestampVerificationOptions(t *testing.T) {
 			}
 
 			// Mock signature validation (minimal)
-			if tt.hasTimestamp {
-				// Mock timestamp - not used in this test
-			}
+			// Note: timestamp handling is not tested here
 
 			// This is a conceptual test - in practice, you'd need to test with real PKCS7 data
 			// For now, we can at least verify the options are set correctly

--- a/verify/keyusage_test.go
+++ b/verify/keyusage_test.go
@@ -3,9 +3,6 @@ package verify
 import (
 	"crypto/x509"
 	"testing"
-	"time"
-
-	"github.com/digitorus/timestamp"
 )
 
 func TestValidateKeyUsage(t *testing.T) {
@@ -317,14 +314,9 @@ func TestTimestampVerificationOptions(t *testing.T) {
 				ValidateTimestampCertificates: tt.validateTimestampCertificates,
 			}
 
-			// Mock signer with or without timestamp
-			signer := &Signer{}
+			// Mock signature validation (minimal)
 			if tt.hasTimestamp {
-				// Mock timestamp - we can't easily create a real one here
-				// In a real test, you'd need to create a proper timestamp.Timestamp
-				signer.TimeStamp = &timestamp.Timestamp{
-					Time: time.Now().Add(-24 * time.Hour), // 24 hours ago
-				}
+				// Mock timestamp - not used in this test
 			}
 
 			// This is a conceptual test - in practice, you'd need to test with real PKCS7 data

--- a/verify/revocation_timing_test.go
+++ b/verify/revocation_timing_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/digitorus/pdfsign/common"
 	"github.com/digitorus/timestamp"
 	"golang.org/x/crypto/ocsp"
 )
@@ -91,7 +92,7 @@ func TestRevocationTimingWithMockData(t *testing.T) {
 
 	tests := []struct {
 		name                  string
-		setupValidation       func() (*SignatureInfo, *SignatureValidation)
+		setupValidation       func() (*common.SignatureInfo, *SignatureValidation)
 		mockRevocationTime    time.Time
 		expectedRevokedBefore bool
 		expectedTimeWarnings  int
@@ -100,8 +101,8 @@ func TestRevocationTimingWithMockData(t *testing.T) {
 	}{
 		{
 			name: "Embedded timestamp - revoked before signing",
-			setupValidation: func() (*SignatureInfo, *SignatureValidation) {
-				info := &SignatureInfo{
+			setupValidation: func() (*common.SignatureInfo, *SignatureValidation) {
+				info := &common.SignatureInfo{
 					TimeStamp: &timestamp.Timestamp{
 						Time: baseTime,
 					},
@@ -121,8 +122,8 @@ func TestRevocationTimingWithMockData(t *testing.T) {
 		},
 		{
 			name: "Embedded timestamp - revoked after signing",
-			setupValidation: func() (*SignatureInfo, *SignatureValidation) {
-				info := &SignatureInfo{
+			setupValidation: func() (*common.SignatureInfo, *SignatureValidation) {
+				info := &common.SignatureInfo{
 					TimeStamp: &timestamp.Timestamp{
 						Time: baseTime,
 					},
@@ -142,8 +143,8 @@ func TestRevocationTimingWithMockData(t *testing.T) {
 		},
 		{
 			name: "Signature time fallback - revoked after",
-			setupValidation: func() (*SignatureInfo, *SignatureValidation) {
-				info := &SignatureInfo{
+			setupValidation: func() (*common.SignatureInfo, *SignatureValidation) {
+				info := &common.SignatureInfo{
 					SignatureTime: &baseTime,
 				}
 				validation := &SignatureValidation{
@@ -161,8 +162,8 @@ func TestRevocationTimingWithMockData(t *testing.T) {
 		},
 		{
 			name: "No timestamp - current time",
-			setupValidation: func() (*SignatureInfo, *SignatureValidation) {
-				info := &SignatureInfo{}
+			setupValidation: func() (*common.SignatureInfo, *SignatureValidation) {
+				info := &common.SignatureInfo{}
 				validation := &SignatureValidation{
 					VerificationTime: &time.Time{}, // Zero time for current_time
 					TimeSource:       "current_time",
@@ -184,7 +185,7 @@ func TestRevocationTimingWithMockData(t *testing.T) {
 			initialWarnings := len(validation.TimeWarnings)
 
 			// Create a mock certificate for testing
-			cert := &Certificate{
+			cert := &common.Certificate{
 				RevocationTime:       &tt.mockRevocationTime,
 				RevokedBeforeSigning: false, // Will be set by our logic
 			}
@@ -240,7 +241,7 @@ func TestRevocationTimingFieldsInCertificate(t *testing.T) {
 	// Test that the new fields are properly populated in the Certificate struct
 	revocationTime := time.Date(2024, 1, 10, 12, 0, 0, 0, time.UTC)
 
-	cert := Certificate{
+	cert := common.Certificate{
 		Certificate:          &x509.Certificate{}, // Mock cert
 		RevocationTime:       &revocationTime,
 		RevokedBeforeSigning: true,

--- a/verify/signature.go
+++ b/verify/signature.go
@@ -10,14 +10,15 @@ import (
 	"crypto/sha256"
 
 	"github.com/digitorus/pdf"
+	"github.com/digitorus/pdfsign/common"
 	"github.com/digitorus/pdfsign/revocation"
 	"github.com/digitorus/pkcs7"
 	"github.com/digitorus/timestamp"
 )
 
 // processSignature processes a single digital signature found in the PDF.
-func processSignature(v pdf.Value, file io.ReaderAt, options *VerifyOptions) (SignatureInfo, SignatureValidation, string, error) {
-	info := SignatureInfo{
+func processSignature(v pdf.Value, file io.ReaderAt, options *VerifyOptions) (common.SignatureInfo, SignatureValidation, string, error) {
+	info := common.SignatureInfo{
 		Name:        v.Key("Name").Text(),
 		Reason:      v.Key("Reason").Text(),
 		Location:    v.Key("Location").Text(),
@@ -103,7 +104,7 @@ func processByteRange(v pdf.Value, file io.ReaderAt, p7 *pkcs7.PKCS7) error {
 }
 
 // processTimestamp processes timestamp information from the signature.
-func processTimestamp(p7 *pkcs7.PKCS7, signer *SignatureInfo) error {
+func processTimestamp(p7 *pkcs7.PKCS7, signer *common.SignatureInfo) error {
 	for _, s := range p7.Signers {
 		// Timestamp - RFC 3161 id-aa-timeStampToken
 		for _, attr := range s.UnauthenticatedAttributes {

--- a/verify/signature_unit_test.go
+++ b/verify/signature_unit_test.go
@@ -144,8 +144,8 @@ func TestProcessSignatureUnit_PKCS7ParseError(t *testing.T) {
 
 // --- Unit test for processTimestamp ---
 func TestProcessTimestampUnit_NoTimestamp(t *testing.T) {
-	signer := &Signer{}
-	_ = signer // silence unused
+	validation := &SignatureValidation{}
+	_ = validation // silence unused
 }
 
 // --- Unit test for verifySignature ---
@@ -157,9 +157,9 @@ func TestVerifySignatureUnit_Invalid(t *testing.T) {
 }
 
 func TestVerifySignatureUnit_Valid(t *testing.T) {
-	signer := &Signer{}
-	signer.ValidSignature = true
-	if !signer.ValidSignature {
+	validation := &SignatureValidation{}
+	validation.ValidSignature = true
+	if !validation.ValidSignature {
 		t.Error("expected ValidSignature to be true")
 	}
 }

--- a/verify/types.go
+++ b/verify/types.go
@@ -8,8 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/digitorus/timestamp"
-	"golang.org/x/crypto/ocsp"
+	"github.com/digitorus/pdfsign/common"
 )
 
 // VerifyOptions contains options for PDF signature verification
@@ -54,75 +53,26 @@ type VerifyOptions struct {
 	HTTPTimeout time.Duration
 }
 
-// SignatureInfo contains information about the signer and signature
-// (not related to validation)
-type SignatureInfo struct {
-	Name          string               `json:"name"`
-	Reason        string               `json:"reason"`
-	Location      string               `json:"location"`
-	ContactInfo   string               `json:"contact_info"`
-	SignatureTime *time.Time           `json:"signature_time,omitempty"`
-	TimeStamp     *timestamp.Timestamp `json:"time_stamp"`
-	DocumentHash  string               `json:"document_hash"`
-	SignatureHash string               `json:"signature_hash"`
-	HashAlgorithm string               `json:"hash_algorithm"`
-}
-
 // SignatureValidation contains validation results and technical details
 // (not about the signer's intent)
 type SignatureValidation struct {
-	ValidSignature     bool          `json:"valid_signature"`
-	TrustedIssuer      bool          `json:"trusted_issuer"`
-	RevokedCertificate bool          `json:"revoked_certificate"`
-	Certificates       []Certificate `json:"certificates"`
-	TimestampStatus    string        `json:"timestamp_status,omitempty"`
-	TimestampTrusted   bool          `json:"timestamp_trusted"`
-	VerificationTime   *time.Time    `json:"verification_time"`
-	TimeSource         string        `json:"time_source"`
-	TimeWarnings       []string      `json:"time_warnings,omitempty"`
+	ValidSignature     bool                 `json:"valid_signature"`
+	TrustedIssuer      bool                 `json:"trusted_issuer"`
+	RevokedCertificate bool                 `json:"revoked_certificate"`
+	Certificates       []common.Certificate `json:"certificates"`
+	TimestampStatus    string               `json:"timestamp_status,omitempty"`
+	TimestampTrusted   bool                 `json:"timestamp_trusted"`
+	VerificationTime   *time.Time           `json:"verification_time"`
+	TimeSource         string               `json:"time_source"`
+	TimeWarnings       []string             `json:"time_warnings,omitempty"`
 }
 
 type Response struct {
 	Error string
 
-	DocumentInfo DocumentInfo
+	DocumentInfo common.DocumentInfo
 	Signatures   []struct {
-		Info       SignatureInfo       `json:"info"`
-		Validation SignatureValidation `json:"validation"`
+		Info       common.SignatureInfo `json:"info"`
+		Validation SignatureValidation  `json:"validation"`
 	}
-}
-
-type Certificate struct {
-	Certificate          *x509.Certificate `json:"certificate"`
-	VerifyError          string            `json:"verify_error"`
-	KeyUsageValid        bool              `json:"key_usage_valid"`
-	KeyUsageError        string            `json:"key_usage_error,omitempty"`
-	ExtKeyUsageValid     bool              `json:"ext_key_usage_valid"`
-	ExtKeyUsageError     string            `json:"ext_key_usage_error,omitempty"`
-	OCSPResponse         *ocsp.Response    `json:"ocsp_response"`
-	OCSPEmbedded         bool              `json:"ocsp_embedded"`
-	OCSPExternal         bool              `json:"ocsp_external"`
-	CRLRevoked           time.Time         `json:"crl_revoked"`
-	CRLEmbedded          bool              `json:"crl_embedded"`
-	CRLExternal          bool              `json:"crl_external"`
-	RevocationWarning    string            `json:"revocation_warning,omitempty"`
-	RevocationTime       *time.Time        `json:"revocation_time,omitempty"` // When the certificate was revoked (if applicable)
-	RevokedBeforeSigning bool              `json:"revoked_before_signing"`    // Whether revocation occurred before signing
-}
-
-// DocumentInfo contains document information.
-type DocumentInfo struct {
-	Author     string `json:"author"`
-	Creator    string `json:"creator"`
-	Hash       string `json:"hash"`
-	Name       string `json:"name"`
-	Permission string `json:"permission"`
-	Producer   string `json:"producer"`
-	Subject    string `json:"subject"`
-	Title      string `json:"title"`
-
-	Pages        int       `json:"pages"`
-	Keywords     []string  `json:"keywords"`
-	ModDate      time.Time `json:"mod_date"`
-	CreationDate time.Time `json:"creation_date"`
 }

--- a/verify/types.go
+++ b/verify/types.go
@@ -54,29 +54,42 @@ type VerifyOptions struct {
 	HTTPTimeout time.Duration
 }
 
+// SignatureInfo contains information about the signer and signature
+// (not related to validation)
+type SignatureInfo struct {
+	Name          string               `json:"name"`
+	Reason        string               `json:"reason"`
+	Location      string               `json:"location"`
+	ContactInfo   string               `json:"contact_info"`
+	SignatureTime *time.Time           `json:"signature_time,omitempty"`
+	TimeStamp     *timestamp.Timestamp `json:"time_stamp"`
+	DocumentHash  string               `json:"document_hash"`
+	SignatureHash string               `json:"signature_hash"`
+	HashAlgorithm string               `json:"hash_algorithm"`
+}
+
+// SignatureValidation contains validation results and technical details
+// (not about the signer's intent)
+type SignatureValidation struct {
+	ValidSignature     bool          `json:"valid_signature"`
+	TrustedIssuer      bool          `json:"trusted_issuer"`
+	RevokedCertificate bool          `json:"revoked_certificate"`
+	Certificates       []Certificate `json:"certificates"`
+	TimestampStatus    string        `json:"timestamp_status,omitempty"`
+	TimestampTrusted   bool          `json:"timestamp_trusted"`
+	VerificationTime   *time.Time    `json:"verification_time"`
+	TimeSource         string        `json:"time_source"`
+	TimeWarnings       []string      `json:"time_warnings,omitempty"`
+}
+
 type Response struct {
 	Error string
 
 	DocumentInfo DocumentInfo
-	Signers      []Signer
-}
-
-type Signer struct {
-	Name               string               `json:"name"`
-	Reason             string               `json:"reason"`
-	Location           string               `json:"location"`
-	ContactInfo        string               `json:"contact_info"`
-	ValidSignature     bool                 `json:"valid_signature"`
-	TrustedIssuer      bool                 `json:"trusted_issuer"`
-	RevokedCertificate bool                 `json:"revoked_certificate"`
-	Certificates       []Certificate        `json:"certificates"`
-	TimeStamp          *timestamp.Timestamp `json:"time_stamp"`
-	SignatureTime      *time.Time           `json:"signature_time,omitempty"`   // Time from the signature object, may be untrusted
-	TimestampStatus    string               `json:"timestamp_status,omitempty"` // "valid", "invalid", "missing"
-	TimestampTrusted   bool                 `json:"timestamp_trusted"`          // Whether timestamp certificate chain is trusted
-	VerificationTime   *time.Time           `json:"verification_time"`          // Time used for certificate validation
-	TimeSource         string               `json:"time_source"`                // "embedded_timestamp", "signature_time", "current_time"
-	TimeWarnings       []string             `json:"time_warnings,omitempty"`    // Warnings about time validation
+	Signatures   []struct {
+		Info       SignatureInfo       `json:"info"`
+		Validation SignatureValidation `json:"validation"`
+	}
 }
 
 type Certificate struct {

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -94,7 +94,7 @@ func VerifyWithOptions(file io.ReaderAt, size int64, options *VerifyOptions) (ap
 		}
 
 		// Use the new modular signature processing function
-		signer, errorMsg, err := processSignature(v, file, options)
+		info, validation, errorMsg, err := processSignature(v, file, options)
 		if err != nil {
 			// Skip this signature if there's a critical error
 			continue
@@ -105,7 +105,13 @@ func VerifyWithOptions(file io.ReaderAt, size int64, options *VerifyOptions) (ap
 			apiResp.Error = errorMsg
 		}
 
-		apiResp.Signers = append(apiResp.Signers, signer)
+		apiResp.Signatures = append(apiResp.Signatures, struct {
+			Info       SignatureInfo       `json:"info"`
+			Validation SignatureValidation `json:"validation"`
+		}{
+			Info:       info,
+			Validation: validation,
+		})
 	}
 
 	if apiResp == nil {

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/digitorus/pdf"
+	"github.com/digitorus/pdfsign/common"
 )
 
 // DefaultVerifyOptions returns the default verification options following RFC 9336
@@ -50,7 +51,7 @@ func Verify(file io.ReaderAt, size int64) (apiResp *Response, err error) {
 }
 
 func VerifyWithOptions(file io.ReaderAt, size int64, options *VerifyOptions) (apiResp *Response, err error) {
-	var documentInfo DocumentInfo
+	var documentInfo common.DocumentInfo
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -106,8 +107,8 @@ func VerifyWithOptions(file io.ReaderAt, size int64, options *VerifyOptions) (ap
 		}
 
 		apiResp.Signatures = append(apiResp.Signatures, struct {
-			Info       SignatureInfo       `json:"info"`
-			Validation SignatureValidation `json:"validation"`
+			Info       common.SignatureInfo `json:"info"`
+			Validation SignatureValidation  `json:"validation"`
 		}{
 			Info:       info,
 			Validation: validation,


### PR DESCRIPTION
I made a new version of the #96 with the current structure.

I needed more traceability on emitted signature and found it would be great to output the different hash in play during the signature as well as info concerning the certificate being used.

This can then be used for display purposes or audit trails.

I made sure that struct returned are identical between sign and verify. I also added a test that proves we're returning the exact same hashes between the two.

This are obviously breaking changes like my previous PR but i guess it's for the better.