### PR TITLE
Fix PDF/A validation error in appearance stream length

### DIFF
--- a/sign/appearance.go
+++ b/sign/appearance.go
@@ -61,7 +61,7 @@ func writeFormTypeAndLength(buffer *bytes.Buffer, streamLength int) {
 func writeAppearanceStreamBuffer(buffer *bytes.Buffer, stream []byte) {
 	buffer.WriteString("stream\n")
 	buffer.Write(stream)
-	buffer.WriteString("endstream\n")
+	buffer.WriteString("\nendstream\n")
 }
 
 func (context *SignContext) createImageXObject() ([]byte, []byte, error) {


### PR DESCRIPTION
## Changes
Fixed a PDF/A validation failure by correcting the stream length calculation in appearance objects.

## Problem
The `writeAppearanceStreamBuffer` function was missing the required EOL (end-of-line) marker before the `endstream` keyword. This caused PDF/A validators to fail because the declared `/Length` value didn't match the actual number of bytes in the stream content.

## Solution
Added a newline character before `endstream` in the `writeAppearanceStreamBuffer` function to match the PDF specification requirement and align with how image and mask objects were already being written.

**Before**: `buffer.WriteString("endstream\n")`
**After**: `buffer.WriteString("\nendstream\n")`

## Testing
- All existing tests pass
- The fix ensures consistency with `createImageXObject` and `createAlphaMask` functions which already include this newline

Fixes #114