### PR TITLE
Fix page dict string value corruption in createIncPageUpdate

### DIFF
--- a/sign/pdfvisualsignature.go
+++ b/sign/pdfvisualsignature.go
@@ -156,7 +156,12 @@ func (context *SignContext) createIncPageUpdate(pageNumber, annot uint32) ([]byt
 			page_buffer.WriteString(fmt.Sprintf("    %d 0 R\n", annot))
 			page_buffer.WriteString("  ]\n")
 		default:
-			page_buffer.WriteString(fmt.Sprintf("  /%s %s\n", key, page.Key(key).String()))
+			val := page.Key(key)
+			if val.Kind() == pdf.String {
+				page_buffer.WriteString(fmt.Sprintf("  /%s %s\n", key, pdfString(val.RawString())))
+			} else {
+				page_buffer.WriteString(fmt.Sprintf("  /%s %s\n", key, val.String()))
+			}
 		}
 	}
 


### PR DESCRIPTION
## Bug

`createIncPageUpdate` writes page dictionary string values (like `/LastModified`, `/CreationDate`) using Go double quotes instead of PDF parenthesized strings.

This breaks multi-signature PDFs. After the first signature rewrites the page dict, subsequent calls to `pdf.NewReader` panic:

```
unexpected keyword "\"D:20220711015152-06'00'\"" parsing object
```

## Root Cause

The `default` case uses `page.Key(key).String()` to serialize values. `Value.String()` calls `objfmt()`, which runs `strconv.Quote()` on string values, producing `"text"` instead of `(text)`.

```go
default:
    page_buffer.WriteString(fmt.Sprintf("  /%s %s\n", key, page.Key(key).String()))
```

A page entry like:
```
/LastModified (D:20220711015152-06'00')
```

Gets rewritten as:
```
/LastModified "D:20220711015152-06'00'"
```

Double quotes aren't valid PDF string syntax. The lexer treats it as an unexpected keyword and panics.

## Repro

1. Take a PDF with a string value in a page dictionary (e.g. `/LastModified`)
2. Sign with 2+ signature fields on pages containing that string
3. First signature corrupts the string, second signature panics on parse

## Fix

Check for `pdf.String` kind and use `pdfString(val.RawString())` instead of `val.String()`. `pdfString()` in `sign/helpers.go` escapes `\`, `(`, `)`, `\r` and wraps in `(...)`. `RawString()` gives the unescaped bytes, `pdfString()` re-escapes for valid PDF output.

Fixes #132